### PR TITLE
ASR-186: use per-campaign queues in the scheduler

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -105,27 +105,12 @@ func NewPubSubScheduler(opts Options) (*PubSubScheduler, error) {
 	}, nil
 }
 
-/*func (s *PubSubScheduler) pushTask(task *db.Task) error {
-	return s.cache.ZAdd(CacheKey, &redis.Z{
-		Score:  float64(task.NotBefore.UnixNano()),
-		Member: task,
-	}).Err()
-}*/
-
 func (s *PubSubScheduler) pushCampaignTask(task *db.Task, campaignID uint) error {
 	return s.cache.ZAdd(fmt.Sprintf(CacheKeyF, campaignID), &redis.Z{
 		Score:  float64(task.NotBefore.UnixNano()),
 		Member: task,
 	}).Err()
 }
-
-/*func (s *PubSubScheduler) popTask(task *db.Task) error {
-	z, err := s.cache.BZPopMin(5*time.Second, CacheKey).Result()
-	if err != nil {
-		return err
-	}
-	return task.UnmarshalBinary([]byte(z.Member.(string)))
-}*/
 
 // Since there are multiple per-campaign queues, popTask must
 // scan through the current keys in the cache and peek each

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -28,8 +28,11 @@ import (
 )
 
 const (
-	CacheKeyF = "campaign%d.tasks" // CacheKey format string for normal sprintf use
-	CacheKeyR = "campaign*.tasks"  // CacheKey format string for the redis Scan function
+	// CacheKeyF format string for normal sprintf use
+	CacheKeyF = "campaign%d.tasks"
+
+	// CacheKeyR format string for the redis Scan function
+	CacheKeyR = "campaign*.tasks"
 )
 
 // Scheduler is an interface which wraps several scheduling functions together.


### PR DESCRIPTION
Modified the scheduler to use per-campaign queues. Each task queue is cached in redis via a unique CacheKey based on the the campaign ID. When popping the next task, the scheduler must peek each campaign queue and record which has the highest priority task scheduled. This campaign queue is then popped from.

Testing indicates that redis, as expected, removes empty campaign queues, so not much cleanup is needed there. The campaign queue key can be easily computed from its ID, so extending this functionality to perform more complex campaign queue operations shouldn't be too difficult.