### PR TITLE
ASR-242: fix nozzle rate limiting

### DIFF
--- a/pkg/nozzle/o365/o365.go
+++ b/pkg/nozzle/o365/o365.go
@@ -37,6 +37,11 @@ const (
 		"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3764.0 Safari/537.36"
 )
 
+var (
+	// RateLimiter limits requests from the same worker to a maximum of 3/s
+	RateLimiter = rate.NewLimiter(rate.Every(300*time.Millisecond), 1)
+)
+
 // Driver implements the nozzle.Driver interface.
 type Driver struct{}
 
@@ -58,12 +63,9 @@ func (Driver) New(opts map[string]string) (nozzle.Nozzle, error) {
 		domain = "login.microsoft.com"
 	}
 
-	rl := rate.NewLimiter(rate.Every(300*time.Millisecond), 1)
-
 	return &Nozzle{
-		Domain:      domain,
-		UserAgent:   FrozenUserAgent,
-		RateLimiter: rl,
+		Domain:    domain,
+		UserAgent: FrozenUserAgent,
 	}, nil
 }
 
@@ -75,9 +77,6 @@ type Nozzle struct {
 
 	// UserAgent will override the Go-http-client user-agent in requests
 	UserAgent string
-
-	// RateLimiter controls how frequently we send requests to O365
-	RateLimiter *rate.Limiter
 }
 
 // struct for error response from o365
@@ -203,7 +202,7 @@ func (n *Nozzle) oauth2TokenLogin(username, password string) (*event.AuthRespons
 // invalid, and locked out responses.
 func (n *Nozzle) Login(username, password string) (*event.AuthResponse, error) {
 	ctx := context.Background()
-	err := n.RateLimiter.Wait(ctx)
+	err := RateLimiter.Wait(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The nozzle rate limiter was incorrectly initialized during `New()`, which meant the rate limit applied to the single request sent by each nozzle instance.

This PR moves the rate limiter to a global variable which will allow us to rate limit all concurrent nozzle requests in a process.