### PR TITLE
[ASR-17] the ability to cancel a created campaign

### DIFF
--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -122,6 +122,7 @@ func main() {
 	// routes
 	r.Get("/healthz", s.HealthzHandler)
 	r.Post("/campaign", s.CampaignHandler)
+	r.Post("/cancel", s.CancelHandler)
 	r.Post("/results", s.ResultsHandler)
 	r.Get("/list", s.CampaignListHandler)
 	r.Post("/describe", s.CampaignDescribeHandler)

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -121,8 +121,8 @@ func main() {
 
 	// routes
 	r.Get("/healthz", s.HealthzHandler)
+	r.Post("/campaign/cancel", s.CancelHandler)
 	r.Post("/campaign", s.CampaignHandler)
-	r.Post("/cancel", s.CancelHandler)
 	r.Post("/results", s.ResultsHandler)
 	r.Get("/list", s.CampaignListHandler)
 	r.Post("/describe", s.CampaignDescribeHandler)

--- a/pkg/commands/cancel.go
+++ b/pkg/commands/cancel.go
@@ -1,0 +1,1 @@
+package commands

--- a/pkg/commands/cancel.go
+++ b/pkg/commands/cancel.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"net/http"
+	"strconv"
 )
 
 var cancelCommand = &cobra.Command{
@@ -48,12 +49,17 @@ func init() {
 func cancelPost(cmd *cobra.Command, args []string) {
 	orchestrator := viper.GetString("orchestrator-url")
 
+	cID, err := strconv.ParseFloat(campaignID, 32)
+	if err != nil {
+		log.Fatalf("CampaignID value must be a number")
+	}
+
 	q := map[string]interface{}{
-		"id": campaignID,
+		"ID": cID,
 	}
 
 	buf := new(bytes.Buffer)
-	err := json.NewEncoder(buf).Encode(q)
+	err = json.NewEncoder(buf).Encode(q)
 	if err != nil {
 		log.Fatalf("error encoding cancel json request: %s", err)
 	}

--- a/pkg/commands/cancel.go
+++ b/pkg/commands/cancel.go
@@ -15,10 +15,9 @@
 package commands
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -50,24 +49,10 @@ func init() {
 func cancelPost(cmd *cobra.Command, args []string) {
 	orchestrator := viper.GetString("orchestrator-url")
 
-	var flagFilter = fmt.Sprintf("{\"id\":%s}", campaignID)
+	//Build out our request body using a JSON serialized Query object
+	reqBody := strings.NewReader(fmt.Sprintf("{\"Filter\":{\"id\":%d}}", campaignID))
 
-	var filter map[string]interface{}
-	err := json.Unmarshal([]byte(flagFilter), &filter)
-	if err != nil {
-		log.Fatalf("error during JSON unmarshalling: %s", err)
-	}
-
-	// build our request to the orchestrator.
-	// return all fields (*) and the filter is the campaignID
-	requestBody, err := json.Marshal(map[string]interface{}{
-		"Filter": filter,
-	})
-	if err != nil {
-		log.Fatalf("error during JSON marshalling for request body: %s", err)
-	}
-
-	req, err := http.NewRequest("POST", orchestrator+"/cancel", bytes.NewBuffer(requestBody))
+	req, err := http.NewRequest("POST", orchestrator+"/cancel", reqBody)
 	if err != nil {
 		log.Fatalf("error during request creation: %s", err)
 	}

--- a/pkg/commands/cancel.go
+++ b/pkg/commands/cancel.go
@@ -49,15 +49,19 @@ func init() {
 func cancelPost(cmd *cobra.Command, args []string) {
 	orchestrator := viper.GetString("orchestrator-url")
 
-	var q db.Query
-	q = db.Query{
+	q := db.Query{
 		Filter: map[string]interface{}{
 			"id": campaignID,
 		},
 	}
 
 	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(q)
+	err := json.NewEncoder(buf).Encode(q)
+
+	if err != nil {
+		log.Fatalf("error encoding cancel json request: %s", err)
+	}
+
 	req, err := http.NewRequest("POST", orchestrator+"/cancel", buf)
 
 	if err != nil {

--- a/pkg/commands/cancel.go
+++ b/pkg/commands/cancel.go
@@ -1,1 +1,91 @@
+// Copyright 2020 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cancelCommand = &cobra.Command{
+	Use:   "cancel",
+	Short: "cancel campaign execution",
+	Long:  `can be used to halt a running campaign and stop all further spraying.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		describeGet(cmd, args)
+	},
+}
+
+func init() {
+	cancelCommand.Flags().StringVarP(&campaignID, "campaign", "c", "1",
+		"the identifier of the campaign.")
+	err := cancelCommand.MarkFlagRequired("campaign")
+	if err != nil {
+		log.Fatalf("issue during argument parsing: %s", err)
+	}
+
+	campaignCmd.AddCommand(cancelCommand)
+}
+
+// cancelPost will post the parameters that make up the given campaign
+// and print the parameters to the CLI
+func cancelPost(cmd *cobra.Command, args []string) {
+	orchestrator := viper.GetString("orchestrator-url")
+
+	var flagFilter = fmt.Sprintf("{\"id\":%s}", campaignID)
+
+	var filter map[string]interface{}
+	err := json.Unmarshal([]byte(flagFilter), &filter)
+	if err != nil {
+		log.Fatalf("error during JSON unmarshalling: %s", err)
+	}
+
+	// build our request to the orchestrator.
+	// return all fields (*) and the filter is the campaignID
+	requestBody, err := json.Marshal(map[string]interface{}{
+		"Filter": filter,
+	})
+	if err != nil {
+		log.Fatalf("error during JSON marshalling for request body: %s", err)
+	}
+
+	req, err := http.NewRequest("POST", orchestrator+"/cancel", bytes.NewBuffer(requestBody))
+	if err != nil {
+		log.Fatalf("error during request creation: %s", err)
+	}
+
+	// add Cloudflare Access token to our request
+	err = authenticator.Auth(req)
+	if err != nil {
+		log.Fatalf("error during authentication: %s", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Fatalf("error sending request: %s", err)
+	}
+	defer resp.Body.Close() // nolint:errcheck
+
+	// handle the results from the server
+	if resp.StatusCode != 200 {
+		log.Fatalf("error cancelling campaign from server: %d", resp.StatusCode)
+	}
+}

--- a/pkg/commands/cancel.go
+++ b/pkg/commands/cancel.go
@@ -17,7 +17,6 @@ package commands
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/praetorian-inc/trident/pkg/db"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -34,7 +33,7 @@ var cancelCommand = &cobra.Command{
 }
 
 func init() {
-	cancelCommand.Flags().StringVarP(&campaignID, "campaign", "c", "1",
+	cancelCommand.Flags().StringVarP(&campaignID, "campaign", "c", "",
 		"the identifier of the campaign.")
 	err := cancelCommand.MarkFlagRequired("campaign")
 	if err != nil {
@@ -49,20 +48,17 @@ func init() {
 func cancelPost(cmd *cobra.Command, args []string) {
 	orchestrator := viper.GetString("orchestrator-url")
 
-	q := db.Query{
-		Filter: map[string]interface{}{
-			"id": campaignID,
-		},
+	q := map[string]interface{}{
+		"id": campaignID,
 	}
 
 	buf := new(bytes.Buffer)
 	err := json.NewEncoder(buf).Encode(q)
-
 	if err != nil {
 		log.Fatalf("error encoding cancel json request: %s", err)
 	}
 
-	req, err := http.NewRequest("POST", orchestrator+"/cancel", buf)
+	req, err := http.NewRequest("POST", orchestrator+"/campaign/cancel", buf)
 
 	if err != nil {
 		log.Fatalf("error during request creation: %s", err)

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/praetorian-inc/trident/pkg/db"
 	"net/http"
 	"os"
 	"strings"
@@ -174,7 +175,7 @@ func campaignCreate(cmd *cobra.Command, args []string) {
 	requestBody, err := json.Marshal(map[string]interface{}{
 		"not_before":        parsedNotBefore,
 		"not_after":         parsedNotAfter,
-		"status":            "Active",
+		"status":            db.CampaignStatusActive,
 		"schedule_interval": flagScheduleInterval,
 		"users":             users,
 		"passwords":         passwords,

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -174,6 +174,7 @@ func campaignCreate(cmd *cobra.Command, args []string) {
 	requestBody, err := json.Marshal(map[string]interface{}{
 		"not_before":        parsedNotBefore,
 		"not_after":         parsedNotAfter,
+		"status":            "Active",
 		"schedule_interval": flagScheduleInterval,
 		"users":             users,
 		"passwords":         passwords,

--- a/pkg/commands/describe.go
+++ b/pkg/commands/describe.go
@@ -110,7 +110,7 @@ func describeGet(cmd *cobra.Command, args []string) {
 	if campaign.Status != "" {
 		fmt.Printf("Status:         %s\n", campaign.Status)
 	} else {
-		fmt.Printf("Status:         Active\n")
+		fmt.Printf("Status:         %s\n", db.CampaignStatusActive)
 	}
 	fmt.Printf("User Count:     %d\n", len(campaign.Users))
 	fmt.Printf("Password Count: %d\n", len(campaign.Passwords))

--- a/pkg/commands/describe.go
+++ b/pkg/commands/describe.go
@@ -107,6 +107,11 @@ func describeGet(cmd *cobra.Command, args []string) {
 	fmt.Printf("-------------------------------------------\n")
 	fmt.Printf("Start Time:     %s\n", campaign.NotBefore)
 	fmt.Printf("End Time:       %s\n", campaign.NotAfter)
+	if campaign.Status != "" {
+		fmt.Printf("Status:         %s\n", campaign.Status)
+	} else {
+		fmt.Printf("Status:         Active\n")
+	}
 	fmt.Printf("User Count:     %d\n", len(campaign.Users))
 	fmt.Printf("Password Count: %d\n", len(campaign.Passwords))
 	fmt.Printf("Provider:       %s\n", campaign.Provider)

--- a/pkg/commands/list.go
+++ b/pkg/commands/list.go
@@ -39,6 +39,7 @@ var listTableHeaderNames = []string{
 	"campaign id",
 	"provider",
 	"metadata",
+	"status",
 	"creation date",
 }
 
@@ -46,6 +47,7 @@ var listTableHeaderFields = []string{
 	"id",
 	"provider",
 	"provider_metadata",
+	"status",
 	"created_at",
 }
 

--- a/pkg/db/client.go
+++ b/pkg/db/client.go
@@ -37,6 +37,11 @@ type Datastore interface {
 	Close() error
 }
 
+const (
+	CAMPAIGN_STATUS_CANCELLED = "Cancelled"
+	CAMPAIGN_STATUS_ACTIVE    = "Active"
+)
+
 // TridentDB implements the Datastore interface. it is backed by a gorm.DB type
 type TridentDB struct {
 	db *gorm.DB
@@ -244,6 +249,29 @@ func (t *TridentDB) ListCampaign() ([]Campaign, error) {
 	}
 
 	return campaigns, nil
+}
+
+func (t *TridentDB) IsCampaignCancelled(campaignId uint) (bool, error) {
+	var matches []Campaign
+
+	var query = Query{
+		Filter: map[string]interface{}{"id": campaignId, "status": CAMPAIGN_STATUS_CANCELLED},
+	}
+
+	err := t.db.
+		Where(query.Filter).
+		Find(&matches).
+		Error
+
+	if err != nil {
+		return false, err
+	}
+
+	if len(matches) != 0 {
+		return true, nil
+	} else {
+		return false, nil
+	}
 }
 
 // DescribeCampaign queries all data about a specific campaign.

--- a/pkg/db/client.go
+++ b/pkg/db/client.go
@@ -259,15 +259,14 @@ func (t *TridentDB) ListCampaign() ([]Campaign, error) {
 
 // IsCampaignCancelled takes a campaign ID and returns true if the campaign status is CampaignStatusCancelled
 func (t *TridentDB) IsCampaignCancelled(campaignID uint) (bool, error) {
-
 	var count int64
-
-	var query = Query{
-		Filter: map[string]interface{}{"id": campaignID, "status": CampaignStatusCancelled},
+	campaign := Campaign{
+		Model: Model{ID: campaignID},
 	}
 
 	err := t.db.
-		Where(query.Filter).
+		Model(&campaign).
+		Where("status = ?", CampaignStatusCancelled).
 		Count(&count).
 		Error
 

--- a/pkg/db/client.go
+++ b/pkg/db/client.go
@@ -34,12 +34,13 @@ type Datastore interface {
 	InsertResult(*Result) error
 	ListCampaign() ([]Campaign, error)
 	DescribeCampaign(Query) (Campaign, error)
+	IsCampaignCancelled(uint) (bool, error)
 	Close() error
 }
 
 const (
-	CAMPAIGN_STATUS_CANCELLED = "Cancelled"
-	CAMPAIGN_STATUS_ACTIVE    = "Active"
+	CampaignStatusCancelled = "Cancelled"
+	CampaignStatusActive    = "Active"
 )
 
 // TridentDB implements the Datastore interface. it is backed by a gorm.DB type
@@ -251,11 +252,12 @@ func (t *TridentDB) ListCampaign() ([]Campaign, error) {
 	return campaigns, nil
 }
 
+// IsCampaignCancelled takes a campaign ID and returns true if the campaign status is CampaignStatusCancelled
 func (t *TridentDB) IsCampaignCancelled(campaignId uint) (bool, error) {
 	var matches []Campaign
 
 	var query = Query{
-		Filter: map[string]interface{}{"id": campaignId, "status": CAMPAIGN_STATUS_CANCELLED},
+		Filter: map[string]interface{}{"id": campaignId, "status": CampaignStatusCancelled},
 	}
 
 	err := t.db.
@@ -269,9 +271,9 @@ func (t *TridentDB) IsCampaignCancelled(campaignId uint) (bool, error) {
 
 	if len(matches) != 0 {
 		return true, nil
-	} else {
-		return false, nil
 	}
+
+	return false, nil
 }
 
 // DescribeCampaign queries all data about a specific campaign.

--- a/pkg/db/client.go
+++ b/pkg/db/client.go
@@ -242,7 +242,7 @@ func (t *TridentDB) StreamingInsertResults() chan *Result {
 func (t *TridentDB) ListCampaign() ([]Campaign, error) {
 	var campaigns []Campaign
 
-	err := t.db.Select([]string{"id", "provider", "provider_metadata", "created_at"}).
+	err := t.db.Select([]string{"id", "provider", "provider_metadata", "status", "created_at"}).
 		Find(&campaigns).Error
 	if err != nil {
 		return nil, err

--- a/pkg/db/client.go
+++ b/pkg/db/client.go
@@ -29,7 +29,7 @@ import (
 // drivers to support other db platforms.
 type Datastore interface {
 	InsertCampaign(*Campaign) error
-
+	UpdateCampaign(*Campaign) error
 	SelectResults(Query) ([]Result, error)
 	InsertResult(*Result) error
 	ListCampaign() ([]Campaign, error)
@@ -112,6 +112,14 @@ func (t *TridentDB) Close() error {
 // future).
 func (t *TridentDB) InsertCampaign(campaign *Campaign) error {
 	return t.db.Create(campaign).Error
+}
+
+// UpdateCampaign is a required function by the Datastore interface. it is a
+// thin wrapper around the Gorm save method, this is largely to help with
+// database mocking for tests (and for help with multiple drivers in the
+// future).
+func (t *TridentDB) UpdateCampaign(campaign *Campaign) error {
+	return t.db.Save(campaign).Error
 }
 
 // SelectResults is a required function by the Datastore interface. it uses a

--- a/pkg/db/client.go
+++ b/pkg/db/client.go
@@ -39,8 +39,11 @@ type Datastore interface {
 }
 
 const (
+	//CampaignStatusCancelled is the value of the Status column if the campaign is Cancelled
 	CampaignStatusCancelled = "Cancelled"
-	CampaignStatusActive    = "Active"
+	//CampaignStatusActive is the value of the Status column if the campaign is not Cancelled
+	//For campaigns added before this change, they may also have an empty Status field for now
+	CampaignStatusActive = "Active"
 )
 
 // TridentDB implements the Datastore interface. it is backed by a gorm.DB type
@@ -253,11 +256,11 @@ func (t *TridentDB) ListCampaign() ([]Campaign, error) {
 }
 
 // IsCampaignCancelled takes a campaign ID and returns true if the campaign status is CampaignStatusCancelled
-func (t *TridentDB) IsCampaignCancelled(campaignId uint) (bool, error) {
+func (t *TridentDB) IsCampaignCancelled(campaignID uint) (bool, error) {
 	var matches []Campaign
 
 	var query = Query{
-		Filter: map[string]interface{}{"id": campaignId, "status": CampaignStatusCancelled},
+		Filter: map[string]interface{}{"id": campaignID, "status": CampaignStatusCancelled},
 	}
 
 	err := t.db.

--- a/pkg/db/models.go
+++ b/pkg/db/models.go
@@ -29,14 +29,19 @@ type Model struct {
 	DeletedAt *time.Time `json:"deleted_at"`
 }
 
+// The CampaignStatus enum indicates the current state of a Campaign
 type CampaignStatus string
 
 const (
 	// CampaignStatusCancelled is the value of the Status column if the campaign is Cancelled
+	// unlike a Halted campaign, a cancelled campaign must be completely restarted, it  cannot be resumed
 	CampaignStatusCancelled CampaignStatus = "Cancelled"
 	// CampaignStatusActive is the value of the Status column if the campaign is not Cancelled
 	// for campaigns added before this change, they may also have an empty Status field for now
 	CampaignStatusActive = "Active"
+	// CampaignStatusHalted is the value of the Status column if the campaign is Halted.
+	// Halted campaigns can be resumed (via ASR-18), whereas cancelling is permanent
+	CampaignStatusHalted = "Halted"
 )
 
 // Campaign stores the metadata associated with an entire password spraying campaign

--- a/pkg/db/models.go
+++ b/pkg/db/models.go
@@ -29,6 +29,16 @@ type Model struct {
 	DeletedAt *time.Time `json:"deleted_at"`
 }
 
+type CampaignStatus string
+
+const (
+	// CampaignStatusCancelled is the value of the Status column if the campaign is Cancelled
+	CampaignStatusCancelled CampaignStatus = "Cancelled"
+	// CampaignStatusActive is the value of the Status column if the campaign is not Cancelled
+	// for campaigns added before this change, they may also have an empty Status field for now
+	CampaignStatusActive = "Active"
+)
+
 // Campaign stores the metadata associated with an entire password spraying campaign
 type Campaign struct {
 	// inherit the base model's fields
@@ -44,7 +54,7 @@ type Campaign struct {
 	ScheduleInterval time.Duration `json:"schedule_interval"`
 
 	// current status of the campaign, used to pause/cancel/resume without deletion
-	Status string `json:"status"`
+	Status CampaignStatus `json:"status"`
 
 	// the slice of usernames to guess in this campaign
 	Users pq.StringArray `json:"users" gorm:"type:varchar(255)[]"`

--- a/pkg/db/models.go
+++ b/pkg/db/models.go
@@ -34,6 +34,8 @@ type Campaign struct {
 	// inherit the base model's fields
 	Model
 
+	//Add status for Campaign here (ex: Cancelled, Paused, w/e)
+
 	// a campaign should not make requests before this time
 	NotBefore time.Time `json:"not_before"`
 

--- a/pkg/db/models.go
+++ b/pkg/db/models.go
@@ -34,8 +34,6 @@ type Campaign struct {
 	// inherit the base model's fields
 	Model
 
-	//Add status for Campaign here (ex: Cancelled, Paused, w/e)
-
 	// a campaign should not make requests before this time
 	NotBefore time.Time `json:"not_before"`
 
@@ -44,6 +42,9 @@ type Campaign struct {
 
 	// a campaign should make requests with this interval in between them
 	ScheduleInterval time.Duration `json:"schedule_interval"`
+
+	// current status of the campaign, used to pause/cancel/resume without deletion
+	Status string `json:"status"`
 
 	// the slice of usernames to guess in this campaign
 	Users pq.StringArray `json:"users" gorm:"type:varchar(255)[]"`

--- a/pkg/db/models.go
+++ b/pkg/db/models.go
@@ -34,7 +34,7 @@ type CampaignStatus string
 
 const (
 	// CampaignStatusCancelled is the value of the Status column if the campaign is Cancelled
-	// unlike a Halted campaign, a cancelled campaign must be completely restarted, it  cannot be resumed
+	// unlike a Halted campaign, a cancelled campaign must be completely restarted, it cannot be resumed
 	CampaignStatusCancelled CampaignStatus = "Cancelled"
 	// CampaignStatusActive is the value of the Status column if the campaign is not Cancelled
 	// for campaigns added before this change, they may also have an empty Status field for now

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -134,6 +134,8 @@ func (s *PubSubScheduler) Schedule(campaign db.Campaign) error {
 	t := campaign.NotBefore
 	for _, p := range campaign.Passwords {
 		for _, u := range campaign.Users {
+			//Check to make sure we're not scheduling a cancelled/paused campaign
+
 			err := s.pushCampaignTask(&db.Task{
 				CampaignID:       campaign.ID,
 				NotBefore:        t,
@@ -156,6 +158,9 @@ func (s *PubSubScheduler) Schedule(campaign db.Campaign) error {
 }
 
 func (s *PubSubScheduler) publishTask(ctx context.Context, task *db.Task) error {
+
+	//Check if task.CampaignID belongs to a cancelled/halted Campaign. If so skip it.
+
 	if time.Until(task.NotBefore) > 5*time.Second {
 		// our task was not ready, reschedule it
 		err := s.pushCampaignTask(task, task.CampaignID)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -160,6 +160,14 @@ func (s *PubSubScheduler) Schedule(campaign db.Campaign) error {
 func (s *PubSubScheduler) publishTask(ctx context.Context, task *db.Task) error {
 
 	//Check if task.CampaignID belongs to a cancelled/halted Campaign. If so skip it.
+	taskIsCancelled, err := s.db.IsCampaignCancelled(task.CampaignID)
+	if err != nil {
+		return fmt.Errorf("Error checking for campaign cancellation during scheduling: %w", err)
+	}
+	if taskIsCancelled {
+		//For now, just do nothing, let the task expire
+		return nil
+	}
 
 	if time.Until(task.NotBefore) > 5*time.Second {
 		// our task was not ready, reschedule it

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -134,8 +134,6 @@ func (s *PubSubScheduler) Schedule(campaign db.Campaign) error {
 	t := campaign.NotBefore
 	for _, p := range campaign.Passwords {
 		for _, u := range campaign.Users {
-			//Check to make sure we're not scheduling a cancelled/paused campaign
-
 			err := s.pushCampaignTask(&db.Task{
 				CampaignID:       campaign.ID,
 				NotBefore:        t,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -157,13 +157,13 @@ func (s *PubSubScheduler) Schedule(campaign db.Campaign) error {
 
 func (s *PubSubScheduler) publishTask(ctx context.Context, task *db.Task) error {
 
-	//Check if task.CampaignID belongs to a cancelled/halted Campaign. If so skip it.
+	// check if task.CampaignID belongs to a cancelled/halted Campaign. If so skip it.
 	taskIsCancelled, err := s.db.IsCampaignCancelled(task.CampaignID)
 	if err != nil {
 		return fmt.Errorf("Error checking for campaign cancellation during scheduling: %w", err)
 	}
 	if taskIsCancelled {
-		//For now, just do nothing, let the task expire
+		// for now, just do nothing, let the task expire
 		return nil
 	}
 

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -160,7 +160,7 @@ func (s *Server) CampaignDescribeHandler(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-// CancelHandler takes a campaignId from the user, then
+// CancelHandler takes a campaignID from the user, then
 // sets its status to cancelled in the database.
 // returns the parameters of that campaign via JSON
 func (s *Server) CancelHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -163,7 +163,11 @@ func (s *Server) CampaignDescribeHandler(w http.ResponseWriter, r *http.Request)
 // CancelHandler takes a campaignID from the user, then
 // sets its status to cancelled in the database.
 func (s *Server) CancelHandler(w http.ResponseWriter, r *http.Request) {
-	var postBody map[string]interface{}
+	type CancelRequest struct {
+		ID uint
+	}
+
+	var postBody CancelRequest
 
 	err := parse.DecodeJSONBody(w, r, &postBody)
 	if err != nil {
@@ -177,13 +181,13 @@ func (s *Server) CancelHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ID := uint(postBody["ID"].(float64))
+	//ID := uint(postBody["ID"].(float64))
 
-	err = s.DB.UpdateCampaignStatus(ID, db.CampaignStatusCancelled)
+	err = s.DB.UpdateCampaignStatus(postBody.ID, db.CampaignStatusCancelled)
 	if err != nil {
 		log.Printf("error updating database: %s", err)
 		http.Error(w, http.StatusText(500), 500)
 	}
 
-	log.Infof("campaign id=%d status has been set to cancelled", ID)
+	log.Infof("campaign id=%d status has been set to cancelled", postBody.ID)
 }

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -181,8 +181,6 @@ func (s *Server) CancelHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//ID := uint(postBody["ID"].(float64))
-
 	err = s.DB.UpdateCampaignStatus(postBody.ID, db.CampaignStatusCancelled)
 	if err != nil {
 		log.Printf("error updating database: %s", err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -159,6 +159,9 @@ func TestCancelHandler(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	err = json.NewEncoder(buf).Encode(q)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req, err := http.NewRequest("POST", "/campaign/cancel", buf)
 	if err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -147,9 +148,19 @@ func TestHealthzHandler(t *testing.T) {
 func TestCancelHandler(t *testing.T) {
 	s := initServer()
 
-	testBody := strings.NewReader(`{"ID":10}`)
+	cID, err := strconv.ParseFloat("10", 32)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	req, err := http.NewRequest("POST", "/campaign/cancel", testBody)
+	q := map[string]interface{}{
+		"ID": cID,
+	}
+
+	buf := new(bytes.Buffer)
+	err = json.NewEncoder(buf).Encode(q)
+
+	req, err := http.NewRequest("POST", "/campaign/cancel", buf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -27,8 +27,8 @@ import (
 
 type mockDB struct{}
 
-func (m *mockDB) IsCampaignCancelled(campaignId uint) (bool, error) {
-	//For now, always return false, but maybe we can make this return true for odd campaignIds
+func (m *mockDB) IsCampaignCancelled(campaignID uint) (bool, error) {
+	//For now, always return false, but maybe we can make this return true for odd campaignIDs
 	return false, nil
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -31,6 +31,10 @@ func (m *mockDB) InsertCampaign(c *db.Campaign) error {
 	return nil
 }
 
+func (m *mockDB) UpdateCampaign(c *db.Campaign) error {
+	return nil
+}
+
 func (m *mockDB) SelectResults(q db.Query) ([]db.Result, error) {
 	var results []db.Result
 
@@ -121,6 +125,29 @@ func TestHealthzHandler(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(s.HealthzHandler)
+
+	handler.ServeHTTP(rr, req)
+
+	// Check the status code is what we expect.
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+}
+
+func TestCancelHandler(t *testing.T) {
+	s := initServer()
+
+	testBody := strings.NewReader("{\"Filter\":{\"id\":1}}")
+
+	req, err := http.NewRequest("POST", "/cancel", testBody)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(s.CancelHandler)
 
 	handler.ServeHTTP(rr, req)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -40,6 +40,10 @@ func (m *mockDB) UpdateCampaign(c *db.Campaign) error {
 	return nil
 }
 
+func (m *mockDB) UpdateCampaignStatus(campaignID uint, status db.CampaignStatus) error {
+	return nil
+}
+
 func (m *mockDB) SelectResults(q db.Query) ([]db.Result, error) {
 	var results []db.Result
 
@@ -143,10 +147,9 @@ func TestHealthzHandler(t *testing.T) {
 func TestCancelHandler(t *testing.T) {
 	s := initServer()
 
-	testBody := strings.NewReader("{\"Filter\":{\"id\":1}}")
+	testBody := strings.NewReader(`{"ID":10}`)
 
-	req, err := http.NewRequest("POST", "/cancel", testBody)
-
+	req, err := http.NewRequest("POST", "/campaign/cancel", testBody)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -27,6 +27,11 @@ import (
 
 type mockDB struct{}
 
+func (m *mockDB) IsCampaignCancelled(campaignId uint) (bool, error) {
+	//For now, always return false, but maybe we can make this return true for odd campaignIds
+	return false, nil
+}
+
 func (m *mockDB) InsertCampaign(c *db.Campaign) error {
 	return nil
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -148,17 +147,12 @@ func TestHealthzHandler(t *testing.T) {
 func TestCancelHandler(t *testing.T) {
 	s := initServer()
 
-	cID, err := strconv.ParseFloat("10", 32)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	q := map[string]interface{}{
-		"ID": cID,
+		"ID": 10,
 	}
 
 	buf := new(bytes.Buffer)
-	err = json.NewEncoder(buf).Encode(q)
+	err := json.NewEncoder(buf).Encode(q)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Added a "Status" DB column for campaigns.

Status is pulled down when listing/describing campaigns now. There is some "legacy" handling code in place for handling campaigns which did not previously have a status value (empty string rather than Active). 

The `cancel` command has been added to `trident-client` and can be invoked by using a command like `trident-client campaign cancel -c CampaignId`.

Once a campaign has been cancelled, the next time that tasks are popped from the ZSET in Redis they will not be re-added or executed. This essentially empties the tasks from Redis and cancels any further activities that are not already pushed to dispatchers.